### PR TITLE
match createNewNewsletter post url to backend url

### DIFF
--- a/src/actions/newsletter.js
+++ b/src/actions/newsletter.js
@@ -34,7 +34,7 @@ export function fetchNewsletterWithId(id) {
 export function createNewNewsletter(formData, success) {
     const token = localStorage.getItem('token');
     return function() {
-        axios.post(`${ROOT_URL}/newsletters/new`, formData, {
+        axios.post(`${ROOT_URL}/newsletter/new`, formData, {
             headers: {
                 'Content-Type': 'multipart/form-data',
                 authorization: token


### PR DESCRIPTION
Reference router.js (https://github.com/bottega-code-school/prop-management-server/blob/master/router.js)

The paths didn't match and it prevented newletters from successfully posting